### PR TITLE
refactor: Confluence空間取得機能を削除

### DIFF
--- a/app/services/external_source_integration.py
+++ b/app/services/external_source_integration.py
@@ -79,7 +79,6 @@ class SourceConfig:
     bearer_token: str | None = None
 
     # 取得設定
-    space_key: str | None = None
     project_key: str | None = None
     max_pages: int = 100
     max_issues: int = 100
@@ -294,9 +293,6 @@ class ConfluenceConnector(BaseConnector):
             "expand": "body.storage,space,version,metadata.properties",
         }
 
-        # スペースフィルタ
-        if self.config.space_key:
-            params["spaceKey"] = self.config.space_key
 
         # 増分同期
         if incremental and self.config.last_sync_time:
@@ -306,8 +302,6 @@ class ConfluenceConnector(BaseConnector):
         if self.config.search_query:
             url = urljoin(self.config.base_url, "/rest/api/content/search")
             params["cql"] = f'text ~ "{self.config.search_query}"'
-            if self.config.space_key:
-                params["cql"] += f' AND space.key = "{self.config.space_key}"'
         else:
             url = urljoin(self.config.base_url, "/rest/api/content")
             params["type"] = "page"
@@ -331,8 +325,6 @@ class ConfluenceConnector(BaseConnector):
 
         # メタデータの構築
         metadata = {
-            "space_key": page.get("space", {}).get("key"),
-            "space_name": page.get("space", {}).get("name"),
             "page_url": urljoin(
                 self.config.base_url, page.get("_links", {}).get("webui", "")
             ),

--- a/tests/test_external_source_integration.py
+++ b/tests/test_external_source_integration.py
@@ -33,7 +33,6 @@ class TestExternalSourceIntegrator:
             auth_type=AuthType.API_TOKEN,
             api_token="test_token",
             username="test@example.com",
-            space_key="TEST",
             max_pages=100,
             timeout=30,
         )
@@ -309,7 +308,6 @@ class TestExternalSourceIntegrator:
         assert transformed["content"] == "Test content"  # HTMLタグが除去される
         assert transformed["source_type"] == "confluence"
         assert transformed["source_id"] == "123456"
-        assert transformed["metadata"]["space_key"] == "TEST"
         assert transformed["metadata"]["page_url"] is not None
 
     @pytest.mark.unit
@@ -376,7 +374,7 @@ class TestExternalSourceIntegrator:
     @pytest.mark.unit
     async def test_filtering_and_search(self, confluence_config: SourceConfig):
         """フィルタリングと検索テスト"""
-        confluence_config.filters = {"labels": ["documentation", "api"], "space": "DEV"}
+        confluence_config.filters = {"labels": ["documentation", "api"]}
         confluence_config.search_query = "REST API"
 
         integrator = ExternalSourceIntegrator(config=confluence_config)


### PR DESCRIPTION
## Summary
DocumentProcessingServiceから不要なConfluence空間取得機能を削除しました。

- SourceConfigからspace_keyパラメータを削除
- ConfluenceConnectorから空間フィルタリングロジックを削除  
- 検索クエリ構築時の空間キー参照を削除
- ドキュメント変換時の空間関連メタデータを削除
- テストケースから空間関連のテストを削除

## Test plan
- [x] 構文チェック済み
- [x] インポートエラーなし確認済み
- [x] 既存のテストケース更新済み

🤖 Generated with [Claude Code](https://claude.ai/code)